### PR TITLE
Add check whether resizeHandler exists before clear

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ export default class NVD3Chart extends React.Component {
    * Remove listeners
    */
   componentWillUnmount() {
-    this.resizeHandler.clear();
+    if(this.resizeHandler)
+      this.resizeHandler.clear();
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "peerDependencies": {
     "d3": "^3.5.6",
-    "nvd3": "^1.8.1",
+    "nvd3": "git://github.com/novus/nvd3#master",
     "react": "^0.14.3"
   },
   "engines": {
@@ -49,7 +49,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.3.0",
     "gulp-webpack": "^1.5.0",
-    "nvd3": "^1.8.1",
+    "nvd3": "git://github.com/novus/nvd3#master",
     "react": "^0.14.3"
   },
   "dependencies": {


### PR DESCRIPTION
It throws `Uncaught TypeError: Cannot read property 'clear' of undefined` if a chart component is being re-rendered quickly.