### PR TITLE
Class static property fields require a semi-colon

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ export default class NVD3Chart extends React.Component {
   static propTypes: {
     type: React.PropTypes.string.isRequired,
     configure: React.PropTypes.func
-  }
+  };
 
   /**
    * Instantiate a new chart setting


### PR DESCRIPTION
Compile was failing for me, due to this recent Babel change:
https://phabricator.babeljs.io/T6873

Basically it seems that class static property fields now require a semi-colon.