### PR TITLE
Add babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
+    "babel-runtime": "^5.8.34",
     "browser-sync": "^2.8.2",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
Compile was failing for me, complaining that it could not find the babel-runtime dependency.