### PR TITLE
ensure callback triggers on update and resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ export default class NVD3Chart extends React.Component {
    */
   componentDidUpdate() {
     this.renderChart();
+    if (this.props.renderEnd) { // trigger callback (as nvd3 chart.update does not do this)
+      this.props.renderEnd(this.chart);
+    }
   }
 
   /**
@@ -76,7 +79,12 @@ export default class NVD3Chart extends React.Component {
       // Update the chart if the window size change.
       // Save resizeHandle to remove the resize listener later.
       if(!this.resizeHandler)
-        this.resizeHandler = nv.utils.windowResize(this.chart.update);
+        this.resizeHandler = nv.utils.windowResize(function() {
+          this.chart.update();
+          if (this.props.renderEnd) { // trigger callback (as nvd3 chart.update does not do this)
+            this.props.renderEnd(this.chart);
+          }
+        }.bind(this));
 
       // PieCharts are an special case. Their dispacher is the pie component inside the chart.
       dispacher = (this.props.type === 'pieChart') ? this.chart.pie : this.chart;

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,9 @@ export function bindFunctions(o, context) {
   out = Array.isArray(o) ? [] : {};
   for (key in o) {
     v = o[key];
-    if(typeof v === 'object' && v !== null && v.type !== 'function') {
+    if(v == null) {
+      continue;
+    } else if(typeof v === 'object' && v !== null && v.type !== 'function') {
       out[key] = bindFunctions(v, context);
     } else if(v.type === 'function'){
       out[key] = context[v.name];


### PR DESCRIPTION
Hi @topicus, hope all good with you.

Unfortunately `this.props.renderEnd` is only triggered the first time the chart is rendered.

For the project I'm working on, we need the callback to trigger on every chart update or window resize. 

Specifically, our callback renders a grey "predicted values" rectangle on top of the chart, showing the user which values are predictions. So if the data changes or the window is resized, we really need to redraw the grey rectangle.

This patch fixes the problem.

I understand that perhaps the problem should be fixed within nvd3 itself. Still, it would be really great to have this feature as a workaround for now.

Thanks,
Ben

![screen shot 2016-02-22 at 14 15 25](https://cloud.githubusercontent.com/assets/861758/13220650/2882ff2a-d96f-11e5-9b29-6f84492dc1dc.png)
