### PR TITLE
Fix layout broken of chart when resizing browser window

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,11 @@ export default class NVD3Chart extends React.Component {
 
       // Update the chart if the window size change.
       // Save resizeHandle to remove the resize listener later.
-      if(!this.resizeHandler)
-        this.resizeHandler = nv.utils.windowResize(this.chart.update);
+      if(!this.resizeHandler) {
+        this.resizeHandler = nv.utils.windowResize(() => {
+          this.chart.update();
+        });
+      }
 
       // PieCharts and lineCharts are an special case. Their dispacher is the pie component inside the chart.
       // There are some charts do not feature the renderEnd event


### PR DESCRIPTION
I'm writing some line chart with react-nvd3.
Sometimes the line chart is broken when I resize a browser window.

The following is a reproduction code of this issue.
If you resize the window, the line chart will be broken.
https://jsfiddle.net/ktsn/tnef6mey/4/

I guess this is because NVD3 dynamically changes the update function of chart object.
https://github.com/novus/nvd3/blob/master/src/models/lineChart.js#L90
In current react-nvd3, it registers an update function for resize event but it can handle only the initial update function. (And this causes the broken layout)

In this PR, I modified resize handler to adapt to the NVD3's behavior.
And I checked it is fixed locally :)