### PR TITLE
Toggle the Bar Chart visibility.

### DIFF
--- a/examples/barChart/index.js
+++ b/examples/barChart/index.js
@@ -43,8 +43,8 @@
     getInitialState: function(){
       return {visible: true};
     },
-    changeVisibility: function(){
-      this.setState({visible: false});
+    toggleVisibility: function(){;
+      this.setState({visible: !this.state.visible});
     },
     render: function(){
       var chart;
@@ -60,7 +60,7 @@
 
       return (
         <div>
-          <button onClick={this.changeVisibility}>Click me</button>
+          <button onClick={this.toggleVisibility}>Toggle Visibility</button>
           {chart}
         </div>
       );


### PR DESCRIPTION
When I tested the example and the chart simply disappeared after
I clicked on "Click me" button I thought something must be broken.

I think toggling the visibility instead of simply making it disappear
once will be less confusing.